### PR TITLE
feat: Added remove_predicted_seg_errors

### DIFF
--- a/src/cellphe/segmentation/__init__.py
+++ b/src/cellphe/segmentation/__init__.py
@@ -1,0 +1,7 @@
+"""
+    Functions related to predicting and removing segmentation errors.
+"""
+
+from __future__ import annotations
+
+from cellphe.segmentation.seg_errors import remove_predicted_seg_errors

--- a/src/cellphe/segmentation/seg_errors.py
+++ b/src/cellphe/segmentation/seg_errors.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+
+import pandas as pd
+
+
+def remove_predicted_seg_errors(dataset: pd.DataFrame, cellid_label: str, error_cells: list[int]) -> pd.DataFrame:
+    """
+    Remove predicted segmentation errors from a data set.
+
+    This function can be used to automate removal of predicted segmentation
+    errors from the test set.
+
+    :param dataset: Test set for segmentation error predictions to be made
+    :param cellid_label: Label for the column of cell identifiers within the
+    test set.
+    :param error_cells: Output from either predictSegErrors() or predictSegErrors_Ensemble(), a list of cell identifiers for cells classified as segmentation error
+    :return: A dataframe with the predicted errors removed.
+    """
+    return dataset.loc[~dataset[cellid_label].isin(error_cells)]

--- a/tests/test_seg_errors.py
+++ b/tests/test_seg_errors.py
@@ -1,0 +1,16 @@
+from __future__ import annotations
+
+import pandas as pd
+
+from cellphe.segmentation import remove_predicted_seg_errors
+
+
+def test_remove_predicted_seg_errors():
+    df = pd.DataFrame({"CellID": [1, 1, 3, 4, 5], "FrameID": [0, 1, 0, 0, 1], "Feat1": [8, 9, 10, 11, 12]})
+    errors = [1, 4]
+    expected = pd.DataFrame({"CellID": [3, 5], "FrameID": [0, 1], "Feat1": [10, 12]})
+    output = remove_predicted_seg_errors(df, "CellID", errors)
+    # Have to remove index from test as it will be different. The function
+    # output index will have the row numbers from the raw larger dataframe,
+    # while the target only has 1:2
+    pd.testing.assert_frame_equal(output.reset_index(drop=True), expected.reset_index(drop=True))


### PR DESCRIPTION
Also setup the `segmentation` sub-package with imports, so users can write `from cellphe.segmentation import remove_predicted_seg_errors`