### PR TITLE
feat: cleaned up main API

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,10 @@ An example dataset to demonstrate CellPhe’s capabilities is hosted on [Dryad](
 These should be extracted into a suitable location before proceeding
 with the rest of the tutorial.
 
+```python
+from cellphe import copy_features, extract_features, time_series_features
+```
+
 The first step is to prepare a dataframe containing metadata and any
 pre-existing attributes. If PhaseFocus Livecyte or Trackmate software
 has been used to generate the region-of-interest (ROI) files, then a
@@ -52,7 +56,6 @@ experimental setup, only including cells that were tracked for at least
 50 frames.
 
 ``` python
-from cellphe.input import copy_features
 min_frames = 50
 input_feature_table = "05062019_B3_3_Phase-FullFeatureTable.csv"
 feature_table = copy_features(input_feature_table, min_frames, source="Phase")
@@ -72,7 +75,6 @@ in the `frame_folder` directory, while ROI files are named according to
 the `ROI_filename` column and located in the `roi_folder` directory.
 
 ``` python
-from cellphe.features import extract_features
 roi_folder = "05062019_B3_3_Phase"
 image_folder = "05062019_B3_3_imagedata"
 new_features = extract_features(feature_table, roi_folder, image_folder, framerate=0.0028)
@@ -88,6 +90,5 @@ output in the form of a dataframe with the first column being the
 `CellID` used previously.
 
 ``` python
-from cellphe.features import time_series_features
 tsvariables = time_series_features(new_features)
 ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,9 +4,10 @@ build-backend = "flit.buildapi"
 
 [project]
 name =  "cellphe"
-version = "0.0.2"
+version = "0.0.3"
 authors = [
     {name = "Stuart Lacy", email = "stuart.lacy@york.ac.uk"},
+    {name = "Laura Wiggins", email = "l.wiggins@sheffield.ac.uk"},
 ]
 description = "CellPhe: Toolkit for cell phenotyping from time-lapse videos"
 readme = "README.md"

--- a/src/cellphe/__init__.py
+++ b/src/cellphe/__init__.py
@@ -9,6 +9,6 @@ from __future__ import annotations
 
 from cellphe.classification import classify_cells
 from cellphe.clustering import identify_clusters
-from cellphe.features import extract_features, time_series_features
-from cellphe.input import copy_features
+from cellphe.features import cell_features, time_series_features
+from cellphe.input import import_data
 from cellphe.separation import calculate_separation_scores

--- a/src/cellphe/__init__.py
+++ b/src/cellphe/__init__.py
@@ -7,5 +7,8 @@
 
 from __future__ import annotations
 
-# Allow copy_features to be imported directly from the package
+from cellphe.classification import classify_cells
+from cellphe.clustering import identify_clusters
+from cellphe.features import extract_features, time_series_features
 from cellphe.input import copy_features
+from cellphe.separation import calculate_separation_scores

--- a/src/cellphe/features/__init__.py
+++ b/src/cellphe/features/__init__.py
@@ -7,5 +7,5 @@
 
 from __future__ import annotations
 
-from cellphe.features.frame import extract_features
+from cellphe.features.frame import cell_features
 from cellphe.features.time_series import time_series_features

--- a/src/cellphe/features/frame.py
+++ b/src/cellphe/features/frame.py
@@ -93,7 +93,7 @@ STATIC_FEATURE_NAMES = [
 ]
 
 
-def extract_features(
+def cell_features(
     # pylint: disable=too-many-locals, too-many-statements
     df: pd.DataFrame,
     roi_folder: str,

--- a/src/cellphe/input.py
+++ b/src/cellphe/input.py
@@ -16,7 +16,7 @@ from PIL import Image
 from read_roi import read_roi_file
 
 
-def copy_features(file: str, minframes: int, source: str = "Phase") -> pd.DataFrame:
+def import_data(file: str, minframes: int, source: str = "Phase") -> pd.DataFrame:
     """Copy metadata and cell-frame features from an existing PhaseFocus or Trackmate table
 
     Loads the frame and cell IDs along with the filename used to refer to each ROI.

--- a/tests/integration/test_cell_features.py
+++ b/tests/integration/test_cell_features.py
@@ -8,7 +8,7 @@ import pytest
 from PIL import Image
 
 from cellphe.features.frame import *
-from cellphe.input import copy_features, read_roi, read_tiff
+from cellphe.input import import_data, read_roi, read_tiff
 from cellphe.processing import normalise_image
 
 pytestmark = pytest.mark.integration
@@ -36,13 +36,13 @@ def assert_frame_equal_extended_diff(df1, df2):
         )
 
 
-def test_extract_features():
+def test_cell_features():
     # Read features from the full dataset and compare to the output from the R
     # package, saved as CSV
     expected = pd.read_csv("tests/resources/benchmark_features.csv")
-    phase_features = copy_features("data/05062019_B3_3_Phase-FullFeatureTable.csv", 200, source="Phase")
+    phase_features = import_data("data/05062019_B3_3_Phase-FullFeatureTable.csv", 200, source="Phase")
 
-    output = extract_features(phase_features, "data/05062019_B3_3_Phase", "data/05062019_B3_3_imagedata", 0.0028)
+    output = cell_features(phase_features, "data/05062019_B3_3_Phase", "data/05062019_B3_3_imagedata", 0.0028)
     # Rename x and y to match how it was in the R version
     output.rename(columns={"x": "xpos", "y": "ypos"}, inplace=True)
 


### PR DESCRIPTION
Makes all the primary user facing functions importable at the top level, as well as renaming a couple to be more descriptive (`copy_features` is now `import_data` and `extract_features` is now `cell_features`, to be consistent with `time_series_features`).

I've also updated the package metadata with co-author details (waiting on Julie to get back before this PR is merged).