### PR TITLE
feat: adds option to change JVM max heap size

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,7 @@ requires-python = ">=3.8.1"
 dependencies = [
     "cellpose",
     "imbalanced-learn",
+    "JPype1==1.5.0",
     "matplotlib",
     "numpy",
     "pandas",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "flit.buildapi"
 
 [project]
 name =  "cellphe"
-version = "0.2.0"
+version = "0.3.1"
 authors = [
     {name = "Stuart Lacy", email = "stuart.lacy@york.ac.uk"},
     {name = "Laura Wiggins", email = "l.wiggins@sheffield.ac.uk"},

--- a/src/cellphe/imagej.py
+++ b/src/cellphe/imagej.py
@@ -7,8 +7,6 @@
 
 from __future__ import annotations
 
-from typing import Optional
-
 import imagej
 import scyjava as sj
 

--- a/src/cellphe/imagej.py
+++ b/src/cellphe/imagej.py
@@ -7,17 +7,25 @@
 
 from __future__ import annotations
 
+from typing import Optional
+
 import imagej
 import scyjava as sj
 
 
-def setup_imagej() -> None:
+def setup_imagej(max_heap: int | None = None) -> None:
     """
     Sets up a JVM with ImageJ and the TrackMate plugin loaded.
 
+    :param max_heap: Size in GB of the maximum heap size allocated to the JVM.
+    Use if you are encountering memory problems with large datasets. Be careful
+    when using this parameter, the rule of thumb is not to assign more than 80%
+    of your computer's available memory.
     :return: None, although could be updated to return reference to a Java class
     net.imagej.ImageJ.
     """
+    if max_heap is not None and isinstance(max_heap, int) and max_heap > 0:
+        sj.config.add_option(f"-Xmx{max_heap}g")
     imagej.init(["net.imagej:imagej", "sc.fiji:TrackMate:7.13.2"], add_legacy=False)
 
 


### PR DESCRIPTION
Addresses #94 

@llwiggins I've added the option to change the default max heap size in the JVM, which should help with processing large 
datasets. I haven't been able to test it though as my java install is currently not working. 

Before launching into a full dataset process, can you try the following to see if it works?

Create a Python script with the below and then run it, it should tell you the max memory available to your system by default (_should do_, I can't check this until I fix my java).

```
from cellphe.imagej import setup_imagej
import scyjava

setup_imagej()
print(f"Max memory = {scyjava.memory_max() // 1024 // 1024 // 1024}")
```

Then try run it again but passing in the max amount of memory you want, which should be then displayed in the output message.

```
from cellphe.imagej import setup_imagej
import scyjava

setup_imagej(max_heap=6)
print(f"Max memory = {scyjava.memory_max() // 1024 // 1024 // 1024}")
```

By the way, were you on your laptop or Google Colab when you had this issue before?