### PR TITLE
feat: Improved filename -> frame matching

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "flit.buildapi"
 
 [project]
 name =  "cellphe"
-version = "0.3.3"
+version = "0.3.4"
 authors = [
     {name = "Stuart Lacy", email = "stuart.lacy@york.ac.uk"},
     {name = "Laura Wiggins", email = "l.wiggins@sheffield.ac.uk"},

--- a/src/cellphe/features/frame.py
+++ b/src/cellphe/features/frame.py
@@ -7,7 +7,6 @@
 
 from __future__ import annotations
 
-import glob
 import os
 import re
 

--- a/src/cellphe/input.py
+++ b/src/cellphe/input.py
@@ -167,6 +167,7 @@ def track_images(
     tracker_settings: dict = None,
     max_heap: int | None = None,
 ) -> None:
+    # pylint: disable=too-many-positional-arguments
     # pylint: disable=too-many-arguments
     """
     Tracks cells across a set of frames using TrackMate, storing the frame

--- a/src/cellphe/segmentation/seg_errors.py
+++ b/src/cellphe/segmentation/seg_errors.py
@@ -30,6 +30,7 @@ def remove_predicted_seg_errors(dataset: pd.DataFrame, cellid_label: str, error_
 
 
 def predict_segmentation_errors(
+    # pylint: disable=too-many-positional-arguments
     # pylint: disable=too-many-arguments
     errors: pd.DataFrame,
     clean: pd.DataFrame,

--- a/tests/unit/test_extract_features_helpers.py
+++ b/tests/unit/test_extract_features_helpers.py
@@ -402,3 +402,46 @@ def test_skewness():
     input = np.array([5, 6, 7, 8, 8, 8, 9, 10, 11, 12, 13, 17])
     output = skewness(input)
     assert output == pytest.approx(0.9452897)
+
+
+def test_get_frame_id_from_filename_correctly_parses():
+    # Test a full range of:
+    #   - Separator between experiment and number
+    #   - zero padding
+    #   - tif or tiff file extension
+    #   - .ome preceding .tif
+    #   - frame id digit length
+    separators = ["-", "_"]
+    extensions = [".tif", ".tiff", ".ome.tif", ".ome.tiff"]
+    experiments = ["myexperiment", "my-experiment", "my-experiment-5", "my_experiment", "my_experiment_5"]
+    zero_padding = [0, 1, 2, 3, 4]
+    numbers = [3, 17, 323, 1429]
+
+    test_cases = {}
+    for n in numbers:
+        for sep in separators:
+            for ext in extensions:
+                for exp in experiments:
+                    for pad in zero_padding:
+                        test_cases[f"{exp}{sep}{n:0{pad}}{ext}"] = n
+    for test_case, expected in test_cases.items():
+        assert get_frame_id_from_filename(test_case) == expected
+
+
+def test_get_frame_id_from_filename_handles_no_separator():
+    # Still works even if there isn't a separator between experiment name and
+    # frameid. Here can't have a trailing number from the experiment name
+    extensions = [".tif", ".tiff", ".ome.tif", ".ome.tiff"]
+    experiments = ["myexperiment", "my-experiment", "my_experiment"]
+    zero_padding = [0, 1, 2, 3, 4]
+    numbers = [3, 17, 323, 1429]
+
+    test_cases = {}
+    sep = ""
+    for n in numbers:
+        for ext in extensions:
+            for exp in experiments:
+                for pad in zero_padding:
+                    test_cases[f"{exp}{sep}{n:0{pad}}{ext}"] = n
+    for test_case, expected in test_cases.items():
+        assert get_frame_id_from_filename(test_case) == expected


### PR DESCRIPTION
It now handles a greater variety of situations, including:
  - tif and tiff extensions
  - .ome file extensions
  - any separation between experiment label and frameID (previously it was just underscore)
  - any amount of zero padding (previously it was max 4)

Closes #106 