### PR TITLE
feat: Save rois as a zip

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ in further columns.
 from cellphe import cell_features
 ```
 
-`cell_features()` takes as arguments the feature table, the folder where ROIs are saved, the folder where the images are, and the framerate.
+`cell_features()` takes as arguments the feature table, the archive where ROIs are saved, the folder where the images are, and the framerate.
 It expects frames to be named according to the scheme
 `<experiment name>-<frameid>.tif`, where `<frameid>` is a 4 digit
 zero-padded integer corresponding to the `FrameID` column,
@@ -129,9 +129,9 @@ while ROI files are named according to
 the `ROI_filename` column.
 
 ```python
-roi_folder = "05062019_B3_3_Phase"
+roi_archive = "05062019_B3_3_Phase.zip"
 image_folder = "05062019_B3_3_imagedata"
-new_features = cell_features(feature_table, roi_folder, image_folder, framerate=0.0028)
+new_features = cell_features(feature_table, roi_archive, image_folder, framerate=0.0028)
 ```
 
 ### Generating time-series features

--- a/README.md
+++ b/README.md
@@ -63,11 +63,11 @@ segment_images("05062019_B3_3_imagedata", "masks")
 
 Confirm that the `masks` directory has been created and populated with TIFs containing cell masks.
 If it has, then you are ready to track the cells.
-`track_images` takes at minimum 3 arguments: the location of the masks created by `segment_images`, the filename to save the output metadata to, and a folder name to save the ROIs in.
-Optionally you can also save the ROIs as a zip so they can be easily opened in ImageJ, and change the tracking options - by default the Simple LAP method is employed.
+`track_images` takes at minimum 3 arguments: the location of the masks created by `segment_images`, the filename to save the output metadata to, and a filename for the output ROI zip.
+Optionally you can also change the tracking options - by default the Simple LAP method is employed - with the `tracker` and `tracker_settings` arguments.
 
 ```python
-track_images("masks", "tracked.csv", "rois")
+track_images("masks", "tracked.csv", "rois.zip")
 ```
 
 Confirm that the `tracked.csv` file was created and the `rois` folder has been populated with ROI files.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "flit.buildapi"
 
 [project]
 name =  "cellphe"
-version = "0.3.4"
+version = "0.3.5"
 authors = [
     {name = "Stuart Lacy", email = "stuart.lacy@york.ac.uk"},
     {name = "Laura Wiggins", email = "l.wiggins@sheffield.ac.uk"},

--- a/src/cellphe/input.py
+++ b/src/cellphe/input.py
@@ -161,8 +161,7 @@ def segment_images(input_dir: str, output_dir: str) -> None:
 def track_images(
     mask_dir: str,
     csv_filename: str,
-    roi_folder: str,
-    create_roi_zip: bool = False,
+    roi_filename: str = "rois.zip",
     tracker: str = "SimpleLAP",
     tracker_settings: dict = None,
     max_heap: int | None = None,
@@ -189,19 +188,13 @@ def track_images(
     :param csv_filename: Filename for the resultant CSV.
     :param roi_folder: Folder where ROIs will be saved to. Will be created if it
         doesn't exist.
-    :param create_roi_zip: Whether to create a Zip archive of the ROI files. If
-        selected, a zip will be created with the name '<roi_folder>.zip', at the
-        level above the roi_folder.
+    :param roi_filename: Filename of output archive.
     :param max_heap: Size in GB of the maximum heap size allocated to the JVM.
         Use if you are encountering memory problems with large datasets. Be careful
         when using this parameter, the rule of thumb is not to assign more than 80%
         of your computer's available memory.
     :return: None, writes the CSV file and ROI files to disk as a side-effect.
     """
-    try:
-        os.makedirs(roi_folder, exist_ok=True)
-    except FileExistsError:
-        pass  # exist_ok doesn't work if dir exists but with different mode
     setup_imagej(max_heap)
 
     imp = read_image_stack(mask_dir)
@@ -227,4 +220,4 @@ def track_images(
 
     # Write CSV and ROIs to disk
     comb_df.to_csv(csv_filename, index=False)
-    save_rois(rois, roi_folder, create_roi_zip)
+    save_rois(rois, roi_filename)

--- a/src/cellphe/processing/roi.py
+++ b/src/cellphe/processing/roi.py
@@ -7,11 +7,8 @@
 
 from __future__ import annotations
 
-import os
-import shutil
-
 import numpy as np
-from roifile import ImagejRoi
+from roifile import ImagejRoi, roiwrite
 
 # pylint doesn't recognise line
 # pylint: disable=no-name-in-module
@@ -184,7 +181,7 @@ def interpolate_between_points(coords: np.array) -> np.array:
     return new_coords
 
 
-def save_rois(rois: list[dict], output_folder: str, create_zip: bool = False):
+def save_rois(rois: list[dict], filename: str = "rois.zip"):
     """
     Saves ROIs to disk.
 
@@ -193,19 +190,15 @@ def save_rois(rois: list[dict], output_folder: str, create_zip: bool = False):
         - CellID: Cell ID
         - FrameID: Frame ID
         - filename: Filename to save the ROI to
-    :param output_folder: Folder where ROIs will be saved to. Will be created if it
-        doesn't exist.
-    :param create_zip: Whether to create a Zip archive of the ROI files. If
-        selected, a zip will be created with the name '<output_folder>.zip', at the
-        level above the roi_folder.
+    :param filename: Filename of output archive.
     :return: None, writes to disk as a side-effect.
     """
+    roi_objs = []
     for roi in rois:
-        fn = os.path.join(output_folder, f"{roi['Filename']}.roi")
         new_coords = interpolate_between_points(roi["coords"].astype(int))
         roi_obj = ImagejRoi.frompoints(new_coords)
         roi_obj.position = roi["FrameID"]
-        roi_obj.tofile(fn)
+        roi_obj.name = roi["Filename"]
+        roi_objs.append(roi_obj)
 
-    if create_zip:
-        shutil.make_archive(output_folder, "zip", output_folder)
+    roiwrite(filename, roi_objs)

--- a/tests/integration/test_cell_features.py
+++ b/tests/integration/test_cell_features.py
@@ -42,7 +42,7 @@ def test_cell_features():
     expected = pd.read_csv("tests/resources/benchmark_features.csv")
     phase_features = import_data("data/05062019_B3_3_Phase-FullFeatureTable.csv", "Phase", 200)
 
-    output = cell_features(phase_features, "data/05062019_B3_3_Phase", "data/05062019_B3_3_imagedata", 0.0028)
+    output = cell_features(phase_features, "data/05062019_B3_3_Phase.zip", "data/05062019_B3_3_imagedata", 0.0028)
     # Rename x and y to match how it was in the R version
     output.rename(columns={"x": "xpos", "y": "ypos"}, inplace=True)
 


### PR DESCRIPTION
Saves the ROIs a ZIP, addressing #108 

This has several benefits, the main one being that a single archive is easier to distribute and work with than tens/hundreds of thousands of files, particularly on HPC filesystems, and the ROIs take up less space on disk. Imagej is equally happy to accept ZIPs as folders.

@llwiggins Any thoughts or reasons to not do this?