### PR TITLE
fix: default tracker

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "flit.buildapi"
 
 [project]
 name =  "cellphe"
-version = "0.3.6"
+version = "0.3.7"
 authors = [
     {name = "Stuart Lacy", email = "stuart.lacy@york.ac.uk"},
     {name = "Laura Wiggins", email = "l.wiggins@sheffield.ac.uk"},

--- a/src/cellphe/input.py
+++ b/src/cellphe/input.py
@@ -183,7 +183,7 @@ def track_images(
     mask_dir: str,
     csv_filename: str,
     roi_filename: str = "rois.zip",
-    tracker: str = "SimpleLAP",
+    tracker: str = "SimpleSparseLAP",
     tracker_settings: dict = None,
     max_heap: int | None = None,
 ) -> None:


### PR DESCRIPTION
When the option to include multiple trackers was implemented, the default tracker wasn't changed.
This also highlights a lack in the testing coverage for an end-to-end run of segmentation and tracking.