### PR TITLE
hotfix: Correctly parse TrackMate options

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "flit.buildapi"
 
 [project]
 name =  "cellphe"
-version = "0.4.1"
+version = "0.4.2"
 authors = [
     {name = "Stuart Lacy", email = "stuart.lacy@york.ac.uk"},
     {name = "Laura Wiggins", email = "l.wiggins@sheffield.ac.uk"},

--- a/src/cellphe/trackmate.py
+++ b/src/cellphe/trackmate.py
@@ -196,12 +196,12 @@ def load_tracker(settings, tracker: str, tracker_settings: dict) -> None:
             if isinstance(v, dict):
                 hash_map = sj.jimport("java.util.HashMap")
                 val = hash_map(v)
-            elif isinstance(v, int):
-                jint = sj.jimport("java.lang.Integer")
-                val = jint(v)
             elif isinstance(v, bool):
                 jbool = sj.jimport("java.lang.Boolean")
                 val = jbool(v)
+            elif isinstance(v, int):
+                jint = sj.jimport("java.lang.Integer")
+                val = jint(v)
             else:
                 val = v
             settings.trackerSettings[k] = val

--- a/src/cellphe/trackmate.py
+++ b/src/cellphe/trackmate.py
@@ -199,6 +199,9 @@ def load_tracker(settings, tracker: str, tracker_settings: dict) -> None:
             elif isinstance(v, int):
                 jint = sj.jimport("java.lang.Integer")
                 val = jint(v)
+            elif isinstance(v, bool):
+                jbool = sj.jimport("java.lang.Boolean")
+                val = jbool(v)
             else:
                 val = v
             settings.trackerSettings[k] = val

--- a/src/cellphe/trackmate.py
+++ b/src/cellphe/trackmate.py
@@ -192,7 +192,12 @@ def load_tracker(settings, tracker: str, tracker_settings: dict) -> None:
     settings.trackerSettings = settings.trackerFactory.getDefaultSettings()
     if tracker_settings is not None:
         for k, v in tracker_settings.items():
-            settings.trackerSettings[k] = v
+            if isinstance(v, dict):
+                hash_map = sj.jimport("java.util.HashMap")
+                val = hash_map(v)
+            else:
+                val = v
+            settings.trackerSettings[k] = val
 
 
 def configure_trackmate(model, settings):

--- a/src/cellphe/trackmate.py
+++ b/src/cellphe/trackmate.py
@@ -192,9 +192,13 @@ def load_tracker(settings, tracker: str, tracker_settings: dict) -> None:
     settings.trackerSettings = settings.trackerFactory.getDefaultSettings()
     if tracker_settings is not None:
         for k, v in tracker_settings.items():
+            # The automatic type conversion fails in some cases
             if isinstance(v, dict):
                 hash_map = sj.jimport("java.util.HashMap")
                 val = hash_map(v)
+            elif isinstance(v, int):
+                jint = sj.jimport("java.lang.Integer")
+                val = jint(v)
             else:
                 val = v
             settings.trackerSettings[k] = val


### PR DESCRIPTION
The options for TrackMate are supplied as a Python dict which then gets automatically converted into Java data types using `jpype`. However, this automatic conversion seems to parse anything numeric as a floats, including ints and booleans. This causes problems with TrackMate for certain properties that are typed as int or boolean. The fix is to explicitly cast these as the corresponding Java data type in our code.

It also fixes dicts getting automatically parsed as hash map interfaces, rather than a concrete implementation.