### PR TITLE
feat: improved error handling

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "flit.buildapi"
 
 [project]
 name =  "cellphe"
-version = "0.4.3"
+version = "0.4.4"
 authors = [
     {name = "Stuart Lacy", email = "stuart.lacy@york.ac.uk"},
     {name = "Laura Wiggins", email = "l.wiggins@sheffield.ac.uk"},

--- a/src/cellphe/features/frame.py
+++ b/src/cellphe/features/frame.py
@@ -171,7 +171,11 @@ def cell_features(
                 continue
 
             # Calculate static features of the frame/cell pair
-            static_features = extract_static_features(image, roi)
+            try:
+                static_features = extract_static_features(image, roi)
+            except RuntimeError as e:
+                print(f"Error processing cell {cell_id} on frame {frame_id}: {e}")
+                continue
 
             # Collate into a dict that will later populate a data frame
             record = dict(zip(STATIC_FEATURE_NAMES, static_features))
@@ -576,6 +580,9 @@ def extract_static_features(image: np.array, roi: np.array) -> np.array:
     # Extract sub image info
     sub_image = extract_subimage(image, roi)
     roi = roi - roi.min(axis=0)
+
+    if np.sum(sub_image.type_mask == 1) == 0:
+        raise RuntimeError("No interior pixels found")
 
     # Shape features
     # Averag radius & variance of boundary pixel distance to centre

--- a/src/cellphe/features/time_series.py
+++ b/src/cellphe/features/time_series.py
@@ -166,7 +166,7 @@ def time_series_features(df: pd.DataFrame) -> pd.DataFrame:
     """
     # Remove columns that aren't used, as they aren't either unique identifiers
     # or feature columns
-    df.drop(columns=["ROI_filename"], inplace=True)
+    df = df.drop(columns=["ROI_filename"])
     feature_cols = np.setdiff1d(df.columns.values, ["CellID", "FrameID", "x", "y"])
 
     # Calculate summary statistics

--- a/src/cellphe/features/time_series.py
+++ b/src/cellphe/features/time_series.py
@@ -121,7 +121,16 @@ def wavelet_features(x: pd.Series) -> pd.DataFrame:
     :return: A 1-row DataFrame comprising 9 columns, one for each of the 3
         elevation metrics for each of the 3 Wavelet levels.
     """
-    wave_coefs = haar_approximation_1d(x)
+    # For some reason can't use try except here UNLESS have a line beforehand
+    # that does something with x, even just printing it. Somehow this results in
+    # only returning a single column data frame rather than 9 columns.
+    # No idea how this is occurring but we know that the wavelet transform
+    # needs at least 4 timepoints so will directly check, which doesn't break
+    # anything.
+    if x.size > 3:
+        wave_coefs = haar_approximation_1d(x)
+    else:
+        wave_coefs = [np.array([])] * 3
 
     # For each level of wavelet coefficients calculate the elevation metrics
     metrics = {"asc": lambda y: ascent(y, diff=False), "des": lambda z: descent(z, diff=False), "max": np.max}

--- a/src/cellphe/features/time_series.py
+++ b/src/cellphe/features/time_series.py
@@ -121,18 +121,20 @@ def wavelet_features(x: pd.Series) -> pd.DataFrame:
     :return: A 1-row DataFrame comprising 9 columns, one for each of the 3
         elevation metrics for each of the 3 Wavelet levels.
     """
-    metrics = {"asc": lambda x: ascent(x, diff=False), "des": lambda x: descent(x, diff=False), "max": np.max}
+    wave_coefs = haar_approximation_1d(x)
 
-    try:
-        wave_coefs = haar_approximation_1d(x)
-        wave_coefs_dict = {f"l{i + 1}": x for i, x in enumerate(wave_coefs)}
-        # For each set of wavelet coefficients calculate the elevation metrics
-        res_dict = {f"{kw}_{km}": vm(vw) for kw, vw in wave_coefs_dict.items() for km, vm in metrics.items()}
-    except np.exceptions.AxisError:
-        wave_names = [f"l{i+1}" for i in range(3)]
-        res_dict = {f"{kw}_{km}": np.nan for kw in wave_names for km in metrics.keys()}
+    # For each level of wavelet coefficients calculate the elevation metrics
+    metrics = {"asc": lambda y: ascent(y, diff=False), "des": lambda z: descent(z, diff=False), "max": np.max}
+    res_dict = {}
+    for i, coefs in enumerate(wave_coefs):
+        kw = f"l{i+1}"
+        for km, vm in metrics.items():
+            if coefs.size < 1:
+                val = np.nan
+            else:
+                val = vm(coefs)
+            res_dict[f"{kw}_{km}"] = val
 
-    # Convert into DataFrame for output
     return pd.DataFrame(res_dict, index=[0])
 
 

--- a/src/cellphe/features/time_series.py
+++ b/src/cellphe/features/time_series.py
@@ -136,7 +136,7 @@ def wavelet_features(x: pd.Series) -> pd.DataFrame:
     metrics = {"asc": lambda y: ascent(y, diff=False), "des": lambda z: descent(z, diff=False), "max": np.max}
     res_dict = {}
     for i, coefs in enumerate(wave_coefs):
-        kw = f"l{i+1}"
+        kw = f"l{i + 1}"
         for km, vm in metrics.items():
             if coefs.size < 1:
                 val = np.nan

--- a/src/cellphe/features/time_series.py
+++ b/src/cellphe/features/time_series.py
@@ -121,12 +121,16 @@ def wavelet_features(x: pd.Series) -> pd.DataFrame:
     :return: A 1-row DataFrame comprising 9 columns, one for each of the 3
         elevation metrics for each of the 3 Wavelet levels.
     """
-    wave_coefs = haar_approximation_1d(x)
-
-    # For each set of wavelet coefficients calculate the elevation metrics
-    wave_coefs_dict = {f"l{i + 1}": x for i, x in enumerate(wave_coefs)}
     metrics = {"asc": lambda x: ascent(x, diff=False), "des": lambda x: descent(x, diff=False), "max": np.max}
-    res_dict = {f"{kw}_{km}": vm(vw) for kw, vw in wave_coefs_dict.items() for km, vm in metrics.items()}
+
+    try:
+        wave_coefs = haar_approximation_1d(x)
+        wave_coefs_dict = {f"l{i + 1}": x for i, x in enumerate(wave_coefs)}
+        # For each set of wavelet coefficients calculate the elevation metrics
+        res_dict = {f"{kw}_{km}": vm(vw) for kw, vw in wave_coefs_dict.items() for km, vm in metrics.items()}
+    except np.exceptions.AxisError:
+        wave_names = [f"l{i+1}" for i in range(3)]
+        res_dict = {f"{kw}_{km}": np.nan for kw in wave_names for km in metrics.keys()}
 
     # Convert into DataFrame for output
     return pd.DataFrame(res_dict, index=[0])

--- a/src/cellphe/trackmate.py
+++ b/src/cellphe/trackmate.py
@@ -221,7 +221,5 @@ def configure_trackmate(model, settings):
 
     tm_cls = sj.jimport("fiji.plugin.trackmate.TrackMate")
     trackmate = tm_cls(model, settings)
-    trackmate.computeSpotFeatures(True)
-    trackmate.computeTrackFeatures(True)
 
     return trackmate

--- a/tests/integration/test_time_series_features.py
+++ b/tests/integration/test_time_series_features.py
@@ -47,7 +47,7 @@ def test_time_series_features(frame_df, ts_df):
     assert_frame_equal_extended_diff(ts_df.reset_index(drop=True), output.reset_index(drop=True))
 
 
-def test_time_series_features_short_series(frame_df):
+def test_time_series_features_short_series(frame_df, ts_df):
     # R package uses 'xpos' and 'ypos' - Python package uses 'x' and 'y'
     df = frame_df.loc[frame_df["FrameID"] < 6]
     output = time_series_features(df)
@@ -56,9 +56,10 @@ def test_time_series_features_short_series(frame_df):
     wavelet_regex = re.compile("_l3_")
     wavelet_cols = list(filter(wavelet_regex.search, output.columns.values))
     assert output[wavelet_cols].isna().all().all()
+    assert output.shape[1] == ts_df.shape[1]  # Correct # cols
 
 
-def test_time_series_features_1_short_1_long(frame_df):
+def test_time_series_features_1_short_1_long(frame_df, ts_df):
     # Test with 1 short time series (that will error on wavelet) and 1 long
     df = frame_df.query("CellID == 30 | (CellID == 31 & FrameID <= 5)")
     output = time_series_features(df)
@@ -68,3 +69,4 @@ def test_time_series_features_1_short_1_long(frame_df):
     wavelet_cols = list(filter(wavelet_regex.search, output.columns.values))
     assert output.loc[output["CellID"] == 31, wavelet_cols].isna().all().all()
     assert ~output.loc[output["CellID"] == 30, wavelet_cols].isna().any().any()
+    assert output.shape[1] == ts_df.shape[1]  # Correct # cols

--- a/tests/integration/test_time_series_features.py
+++ b/tests/integration/test_time_series_features.py
@@ -47,7 +47,7 @@ def test_time_series_features(frame_df, ts_df):
     assert_frame_equal_extended_diff(ts_df.reset_index(drop=True), output.reset_index(drop=True))
 
 
-def test_time_series_features_short_series(frame_df, ts_df):
+def test_error_3rd_level_wavelet(frame_df, ts_df):
     # R package uses 'xpos' and 'ypos' - Python package uses 'x' and 'y'
     df = frame_df.loc[frame_df["FrameID"] < 6]
     output = time_series_features(df)
@@ -59,7 +59,7 @@ def test_time_series_features_short_series(frame_df, ts_df):
     assert output.shape[1] == ts_df.shape[1]  # Correct # cols
 
 
-def test_time_series_features_1_short_1_long(frame_df, ts_df):
+def test_error_3rd_level_wavelet_some_cells(frame_df, ts_df):
     # Test with 1 short time series (that will error on wavelet) and 1 long
     df = frame_df.query("CellID == 30 | (CellID == 31 & FrameID <= 5)")
     output = time_series_features(df)
@@ -69,4 +69,17 @@ def test_time_series_features_1_short_1_long(frame_df, ts_df):
     wavelet_cols = list(filter(wavelet_regex.search, output.columns.values))
     assert output.loc[output["CellID"] == 31, wavelet_cols].isna().all().all()
     assert ~output.loc[output["CellID"] == 30, wavelet_cols].isna().any().any()
+    assert output.shape[1] == ts_df.shape[1]  # Correct # cols
+
+
+def test_error_wavelet(frame_df, ts_df):
+    # If we have < 4 timepoints, the wavelet calculation itself fails and all
+    # the wavelet features will be NAN
+    df = frame_df.loc[frame_df["FrameID"] < 4]
+    output = time_series_features(df)
+
+    # All wavelet features should be NA
+    wavelet_regex = re.compile("_l1_l2_l3_")
+    wavelet_cols = list(filter(wavelet_regex.search, output.columns.values))
+    assert output[wavelet_cols].isna().all().all()
     assert output.shape[1] == ts_df.shape[1]  # Correct # cols

--- a/tests/integration/test_time_series_features.py
+++ b/tests/integration/test_time_series_features.py
@@ -12,6 +12,18 @@ from cellphe.input import read_roi
 pytestmark = pytest.mark.integration
 
 
+@pytest.fixture()
+def frame_df():
+    df = pd.read_csv("tests/resources/benchmark_features.csv")
+    df.rename(columns={"xpos": "x", "ypos": "y"}, inplace=True)
+    yield df
+
+
+@pytest.fixture()
+def ts_df():
+    yield pd.read_csv("tests/resources/benchmark_time_series_features.csv")
+
+
 def assert_frame_equal_extended_diff(df1, df2):
     cols = df1.columns.values
     incorrect_cols = []
@@ -28,23 +40,17 @@ def assert_frame_equal_extended_diff(df1, df2):
         )
 
 
-def test_time_series_features():
+def test_time_series_features(frame_df, ts_df):
     # R package uses 'xpos' and 'ypos' - Python package uses 'x' and 'y'
-    frame_features = pd.read_csv("tests/resources/benchmark_features.csv")
-    frame_features = frame_features.rename(columns={"xpos": "x", "ypos": "y"})
-    expected = pd.read_csv("tests/resources/benchmark_time_series_features.csv")
-    output = time_series_features(frame_features)
-    output = output.rename(columns={"x": "xpos", "y": "ypos"})
-
-    assert_frame_equal_extended_diff(expected.reset_index(drop=True), output.reset_index(drop=True))
+    output = time_series_features(frame_df)
+    output.rename(columns={"x": "xpos", "y": "ypos"}, inplace=True)
+    assert_frame_equal_extended_diff(ts_df.reset_index(drop=True), output.reset_index(drop=True))
 
 
-def test_time_series_features_short_series():
+def test_time_series_features_short_series(frame_df):
     # R package uses 'xpos' and 'ypos' - Python package uses 'x' and 'y'
-    frame_features = pd.read_csv("tests/resources/benchmark_features.csv")
-    frame_features = frame_features.loc[frame_features["FrameID"] < 6]
-    frame_features = frame_features.rename(columns={"xpos": "x", "ypos": "y"})
-    output = time_series_features(frame_features)
+    df = frame_df.loc[frame_df["FrameID"] < 6]
+    output = time_series_features(df)
 
     # All wavelet features should be NA
     wavelet_regex = re.compile("_l1|l2|l3_")
@@ -52,4 +58,13 @@ def test_time_series_features_short_series():
     assert output[wavelet_cols].isna().all().all()
 
 
-# TODO test only sets cells with insufficient temporal resolution to NAs
+def test_time_series_features_1_short_1_long(frame_df):
+    # Test with 1 short time series (that will error on wavelet) and 1 long
+    df = frame_df.query("CellID == 30 | (CellID == 31 & FrameID <= 5)")
+    output = time_series_features(df)
+
+    # All wavelet features for CellID 31 should be NA, but not NA for 30
+    wavelet_regex = re.compile("_l1|l2|l3_")
+    wavelet_cols = list(filter(wavelet_regex.search, output.columns.values))
+    assert output.loc[output["CellID"] == 31, wavelet_cols].isna().all().all()
+    assert ~output.loc[output["CellID"] == 30, wavelet_cols].isna().any().any()

--- a/tests/integration/test_time_series_features.py
+++ b/tests/integration/test_time_series_features.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import re
+
 import pandas as pd
 import pytest
 from PIL import Image
@@ -35,3 +37,19 @@ def test_time_series_features():
     output = output.rename(columns={"x": "xpos", "y": "ypos"})
 
     assert_frame_equal_extended_diff(expected.reset_index(drop=True), output.reset_index(drop=True))
+
+
+def test_time_series_features_short_series():
+    # R package uses 'xpos' and 'ypos' - Python package uses 'x' and 'y'
+    frame_features = pd.read_csv("tests/resources/benchmark_features.csv")
+    frame_features = frame_features.loc[frame_features["FrameID"] < 6]
+    frame_features = frame_features.rename(columns={"xpos": "x", "ypos": "y"})
+    output = time_series_features(frame_features)
+
+    # All wavelet features should be NA
+    wavelet_regex = re.compile("_l1|l2|l3_")
+    wavelet_cols = list(filter(wavelet_regex.search, output.columns.values))
+    assert output[wavelet_cols].isna().all().all()
+
+
+# TODO test only sets cells with insufficient temporal resolution to NAs

--- a/tests/integration/test_time_series_features.py
+++ b/tests/integration/test_time_series_features.py
@@ -52,8 +52,8 @@ def test_time_series_features_short_series(frame_df):
     df = frame_df.loc[frame_df["FrameID"] < 6]
     output = time_series_features(df)
 
-    # All wavelet features should be NA
-    wavelet_regex = re.compile("_l1|l2|l3_")
+    # All third level wavelet features should be NA
+    wavelet_regex = re.compile("_l3_")
     wavelet_cols = list(filter(wavelet_regex.search, output.columns.values))
     assert output[wavelet_cols].isna().all().all()
 
@@ -63,8 +63,8 @@ def test_time_series_features_1_short_1_long(frame_df):
     df = frame_df.query("CellID == 30 | (CellID == 31 & FrameID <= 5)")
     output = time_series_features(df)
 
-    # All wavelet features for CellID 31 should be NA, but not NA for 30
-    wavelet_regex = re.compile("_l1|l2|l3_")
+    # All third level wavelet features for CellID 31 should be NA, but not NA for 30
+    wavelet_regex = re.compile("_l3_")
     wavelet_cols = list(filter(wavelet_regex.search, output.columns.values))
     assert output.loc[output["CellID"] == 31, wavelet_cols].isna().all().all()
     assert ~output.loc[output["CellID"] == 30, wavelet_cols].isna().any().any()


### PR DESCRIPTION
Safely handle errors that occur in edge cases:

  - When a cell has no interior pixels, it is skipped in `frame_features`
  - `time_series_features` will check that the time-series has sufficient length to calculate the level 3 wavelet coefficients, if not, the wavelet features (`l1/l2/l3`_asc/desc/max`) are set to `NaN`
  - `time_series_features` checks if all 3 levels of the wavelet transform worked, any erroneous ones (typically just third level) are set to `NaN`